### PR TITLE
Add data object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
-HOSTNAME=github.com
-NAMESPACE=trevex
-NAME=ldap
-BINARY=terraform-provider-${NAME}
-VERSION=0.2
-OS_ARCH=darwin_amd64
+HOSTNAME ?= github.com
+NAMESPACE ?= trevex
+NAME ?= ldap
+BINARY = terraform-provider-${NAME}
+VERSION ?= 0.2
+OS_ARCH ?= darwin_amd64
 
 default: install
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/go-ldap/ldap/v3 v3.2.4
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4
+	github.com/pkg/errors v0.8.1
 	golang.org/x/text v0.3.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/g
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
+github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
@@ -61,6 +62,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -79,9 +81,9 @@ github.com/go-git/go-git/v5 v5.1.0/go.mod h1:ZKfuPUoY1ZqIG4QG9BDBh3G4gLM5zvPuSJA
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-ldap/ldap v3.0.3+incompatible h1:HTeSZO8hWMS1Rgb2Ziku6b8a7qRIZZMHjsvuZyatzwk=
 github.com/go-ldap/ldap/v3 v3.2.4 h1:PFavAq2xTgzo/loE8qNXcQaofAaqIpI4WgaLdv+1l3E=
 github.com/go-ldap/ldap/v3 v3.2.4/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjRvjKpyMg=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -116,6 +118,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -169,6 +172,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -177,11 +181,14 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -204,11 +211,14 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -219,6 +229,7 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
@@ -394,6 +405,7 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -414,6 +426,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -471,11 +484,13 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/provider/data_ldap_object.go
+++ b/provider/data_ldap_object.go
@@ -1,0 +1,239 @@
+// Heavily based on https://github.com/Pryz/terraform-provider-ldap, see LICENSE
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pkg/errors"
+)
+
+var SEARCH_DEPTHS = map[int][]string{
+	ldap.ScopeWholeSubtree: {
+		"sub",
+		"subtree",
+		"wholeSubtree",
+	},
+	ldap.ScopeBaseObject: {
+		"base",
+		"baseObject",
+	},
+	ldap.ScopeSingleLevel: {
+		"one",
+		"singleLevel",
+	},
+}
+
+// searchDepthLookup normalizes the name of a search depth
+func normalizeSearchDepth(search string) int {
+	lowerSearch := strings.ToLower(search)
+	for val, alternates := range SEARCH_DEPTHS {
+		for _, a := range alternates {
+			if strings.ToLower(a) == lowerSearch {
+				return val
+			}
+		}
+	}
+	return -1
+}
+
+func depthHelpString() string {
+	out := []string{}
+	for _, alternates := range SEARCH_DEPTHS {
+		out = append(out, fmt.Sprintf("%s (or %s)", alternates[0], strings.Join(alternates[1:], ", ")))
+	}
+
+	return strings.Join(out, ", ")
+}
+
+func dataLDAPObject() *schema.Resource {
+	return &schema.Resource{
+		Read: dataLDAPObjectRead,
+		// Importer: &schema.ResourceImporter{
+		// 	State: resourceLDAPObjectImport,
+		// },
+
+		Schema: map[string]*schema.Schema{
+			"base_dn": {
+				Type:        schema.TypeString,
+				Description: "Base DN to search from",
+				Required:    true,
+			},
+			"depth": {
+				Type: schema.TypeString,
+				// Search depth can be any of the keys or values in SEARCH_DEPTHS
+				Description: "Search depth kind: " + depthHelpString(),
+				Default:     "subtree",
+				Optional:    true,
+			},
+			"search_values": {
+				Type:        schema.TypeMap,
+				Description: "A dict of values to search by, will be AND'd together",
+				Required:    true,
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					Description: "The value to search for on this attribute",
+				},
+			},
+			"dn": {
+				Type:        schema.TypeString,
+				Description: "DN Of the object",
+				Computed:    true,
+			},
+			"attributes": {
+				Type:        schema.TypeSet,
+				Description: "The map of attributes of this object; each attribute can be multi-valued.",
+				Set:         attributeHash,
+				MinItems:    0,
+				Computed:    true,
+
+				Elem: &schema.Schema{
+					Type:        schema.TypeMap,
+					Description: "The list of values for a given attribute.",
+					MinItems:    1,
+					MaxItems:    1,
+					Elem: &schema.Schema{
+						Type:        schema.TypeString,
+						Description: "The individual value for the given attribute.",
+					},
+				},
+			},
+			"attributes_json": {
+				Computed:    true,
+				Type:        schema.TypeMap,
+				Description: "A map of json encoded attribute values. Each entry is a JSON encoded string list",
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					Description: "A json-encoded array of strings",
+				},
+			},
+		},
+	}
+}
+
+func dataLDAPObjectRead(d *schema.ResourceData, meta interface{}) error {
+	return searchLDAPObject(d, meta)
+}
+
+func searchLDAPObject(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ldap.Conn)
+	baseDN := d.Get("base_dn").(string)
+	searchDepthInput := d.Get("depth").(string)
+	searchDepth := normalizeSearchDepth(searchDepthInput)
+
+	if searchDepth < 0 {
+		return fmt.Errorf("Search depth of '%s' not a valid option", searchDepthInput)
+	}
+
+	searchFilters := []string{}
+	if requestedSearch, ok := d.GetOk("search_values"); ok {
+		for key, val := range requestedSearch.(map[string]interface{}) {
+			searchFilters = append(searchFilters, fmt.Sprintf("(%s=%s)", key, val.(string)))
+		}
+	}
+	searchFilter := fmt.Sprintf("(&%s)", strings.Join(searchFilters, ""))
+
+	debugLog("ldap_object::read - looking in %q for %q", baseDN, searchFilter)
+	// when searching by DN, you don't need t specify the base DN a search
+	// filter a "subtree" scope: just put the DN (i.e. the primary key) as the
+	// base DN with a "base object" scope, and the returned object will be the
+	// entry, if it exists
+	request := ldap.NewSearchRequest(
+		baseDN,
+		searchDepth,
+		ldap.NeverDerefAliases, // deref Aliases
+		0,                      // sizeLimit
+		0,                      // timeLimit
+		false,                  // typesOnly
+		searchFilter,           // filter
+		[]string{"*"},          // attributes
+		nil,                    // controls
+	)
+
+	searchResult, err := client.Search(request)
+	if err != nil {
+		if err, ok := err.(*ldap.Error); ok {
+			if err.ResultCode == 32 { // no such object
+				warnLog("ldap_object::read - object not found with filter: %s", searchFilter)
+				return fmt.Errorf("Object not found with filter: %s", searchFilter)
+			}
+		}
+		debugLog("ldap_object::read - search %q returned an error %v", searchFilter, err)
+		return err
+	}
+
+	if len(searchResult.Entries) > 1 {
+		err := fmt.Errorf("There were more than one objects foudn with search %q", searchFilter)
+		errorLog(err.Error())
+		return err
+	} else if len(searchResult.Entries) < 1 {
+		err := fmt.Errorf("There were no objects found against %q", searchFilter)
+		errorLog(err.Error())
+		return err
+	}
+
+	foundObject := searchResult.Entries[0]
+
+	var dn string
+	for _, key := range []string{"dn", "DN", "distinguished_name", "distinguishedName"} {
+		dn = foundObject.GetAttributeValue(key)
+		if dn != "" {
+			traceLog("Found Distinguished Name for object: %s = %q", key, dn)
+			break
+		}
+	}
+
+	if dn == "" {
+		err := fmt.Errorf("Failed to find DN for object %+v", foundObject)
+		errorLog(err.Error())
+		return err
+	}
+
+	traceLog("ldap_object::read - found %q : %+v", dn, foundObject)
+	d.Set("dn", dn)
+	d.SetId("-")
+
+	// now deal with attributes
+	set := &schema.Set{
+		F: attributeHash,
+	}
+
+	jsonAttributes := make(map[string]string)
+
+	for _, attribute := range searchResult.Entries[0].Attributes {
+		debugLog("ldap_object::read - adding attribute %q to %q (%d values)", attribute.Name, dn, len(attribute.Values))
+		// now add each value as an individual entry into the object, because
+		// we do not handle name => []values, and we have a set of maps each
+		// holding a single entry name => value; multiple maps may share the
+		// same key.
+		for _, value := range attribute.Values {
+			traceLog("ldap_object::read - for %q, setting %q => %q", dn, attribute.Name, value)
+			set.Add(map[string]interface{}{
+				attribute.Name: value,
+			})
+		}
+		jsonBytes, err := json.Marshal(attribute.Values)
+		if err != nil {
+			err = errors.Wrapf(err, "Marshalling attribute %s values", attribute.Name)
+			errorLog(err.Error())
+			return err
+		}
+		jsonAttributes[attribute.Name] = string(jsonBytes)
+	}
+
+	if err := d.Set("attributes", set); err != nil {
+		warnLog("ldap_object::read - error setting attributes for %q : %v", dn, err)
+		return err
+	}
+
+	if err := d.Set("attributes_json", jsonAttributes); err != nil {
+		warnLog("ldap_object::read - error setting attributes_json for %q : %v", dn, err)
+		return err
+	}
+
+	return nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -44,7 +46,9 @@ func New(version string) func() *schema.Provider {
 			ResourcesMap: map[string]*schema.Resource{
 				"ldap_object": resourceLDAPObject(),
 			},
-			DataSourcesMap:       map[string]*schema.Resource{},
+			DataSourcesMap: map[string]*schema.Resource{
+				"ldap_object": dataLDAPObject(),
+			},
 			ConfigureContextFunc: providerConfigure,
 		}
 
@@ -98,3 +102,16 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	return l, diags
 }
+
+func leveledLog(level string) func(format string, v ...interface{}) {
+	prefix := fmt.Sprintf("[%s] ", strings.ToUpper(level))
+	return func(format string, v ...interface{}) {
+		log.Printf(prefix+format, v...)
+	}
+}
+
+var traceLog = leveledLog("trace")
+var debugLog = leveledLog("debug")
+var infoLog = leveledLog("info")
+var warnLog = leveledLog("warn")
+var errorLog = leveledLog("error")


### PR DESCRIPTION
This PR adds a data resource type to the provider so one can read objects.

This works really well to pull DN's based off another attribute and then use it somewhere else:

```hcl
variable "users" {
  type = set(string)
  default = [
    "oisaac",
    "auser"
  ]
}

data "ldap_object" "user" {
  for_each = var.users

  base_dn = "OU=Users,OU=Example,DC=ad,DC=example,DC=com"
  search_values = {
    sAMAccountName = each.key
  }
}

resource "ldap_object" "group" {
  dn = "CN=test-terraform,OU=Groups,OU=Example,DC=ad,DC=example,DC=com"
  object_classes = [
    "top",
    "group",
  ]

  attributes = [for u in var.users : { "member" = data.ldap_object.user[u].dn }]
  select_attributes = [
    "member"
  ]
}

// You also get access to attributes as a JSON encoded array which could be helpful
output "json_vals" {
  value = jsondecode(data.ldap_object.user["oisaac"].attributes_json["memberOf"])[0]
}

```
