### PR TITLE
Use default DN if exists

### DIFF
--- a/provider/data_ldap_object.go
+++ b/provider/data_ldap_object.go
@@ -189,12 +189,15 @@ func searchLDAPObject(d *schema.ResourceData, meta interface{}) error {
 
 	foundObject := searchResult.Entries[0]
 
-	var dn string
-	for _, key := range []string{"dn", "DN", "distinguished_name", "distinguishedName"} {
-		dn = foundObject.GetAttributeValue(key)
-		if dn != "" {
-			traceLog("Found Distinguished Name for object: %s = %q", key, dn)
-			break
+	dn := foundObject.DN
+	
+	if dn == "" {
+		for _, key := range []string{"dn", "DN", "distinguished_name", "distinguishedName"} {
+			dn = foundObject.GetAttributeValue(key)
+			if dn != "" {
+				traceLog("Found Distinguished Name for object: %s = %q", key, dn)
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
The LDAP entry object has a field DN and we should use that as the primary DN fields. DN may not be defined in the attributes.