### PR TITLE
goreleaser: Stop ignoring darwin-arm64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,8 +30,6 @@ builds:
       goarch: '386'
     - goos: darwin
       goarch: arm
-    - goos: darwin
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Sorry for the noise, turns out my previous PR was not properly addressing the issue of the missing darwin-arm64 release.